### PR TITLE
Fix shebang and edit setup.py

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@ version: 1.0.{build}
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python34-x64"
+    - PYTHON: "C:\\Python35-x64"
 
 install:
   - cmd: "%PYTHON%\\python.exe setup.py install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.4"
+  - "3.5"
 sudo: false
 
 before_install: pip install codecov

--- a/pyqms/__init__.py
+++ b/pyqms/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.3
+#!/usr/bin/env python
 # encoding: utf-8
 """
     pyQms

--- a/pyqms/__init__.py
+++ b/pyqms/__init__.py
@@ -24,7 +24,7 @@ import sys
 version_info  = (0, 5, 0, 'beta')
 version = '0.5.0-beta'
 
-if not hasattr(sys, "version_info") or sys.version_info < (3, 3):
+if not hasattr(sys, "version_info") or sys.version_info < (3, 5):
     raise RuntimeError("pyQms requires Python 3.3 or later.")
 
 from . import knowledge_base

--- a/pyqms/adaptors.py
+++ b/pyqms/adaptors.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3.4
+#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 # encoding: utf-8
 """

--- a/pyqms/chemical_composition.py
+++ b/pyqms/chemical_composition.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python3.4
+# !/usr/bin/env python
 # encoding: utf-8
 """
     pyQms

--- a/pyqms/isotopologue_library.py
+++ b/pyqms/isotopologue_library.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 """
     pyQms

--- a/pyqms/knowledge_base.py
+++ b/pyqms/knowledge_base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # encoding: utf-8
 

--- a/pyqms/params.py
+++ b/pyqms/params.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3.4
+#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 # encoding: utf-8
 """

--- a/pyqms/results.py
+++ b/pyqms/results.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 """
     pyQms

--- a/pyqms/unimod_mapper.py
+++ b/pyqms/unimod_mapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 """
     pyQms

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 from setuptools import setup
 import os

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from distutils.core import setup
+from setuptools import setup
 import os
 
 version_txt_path = os.path.join(
@@ -23,7 +23,7 @@ setup(
             'kb/ext/unimod.xml',
         ]
     },
-    requires         = ['pymzml'],
+    install_requires         = ['pymzml', 'openpyxl'],
     long_description = "pyQms enables universal and accurate quantification of mass spectrometry data",
     author           = 'Johannes Leufken, Anna Niehues, L. Peter Sarin, Florian Wessels, Michael Hippler, Sebastian A. Leidel and Christian Fufezan',
     author_email     = 'christian@fufezan.net',

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'Operating System :: POSIX :: SunOS/Solaris',
         'Operating System :: Unix',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Scientific/Engineering :: Astronomy',
         'Topic :: Scientific/Engineering :: Atmospheric Science',
         'Topic :: Scientific/Engineering :: Bio-Informatics',

--- a/tests/ChemicalComposition_tests.py
+++ b/tests/ChemicalComposition_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 import pyqms
 import unittest

--- a/tests/Results_test.py
+++ b/tests/Results_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 import pyqms
 import unittest

--- a/tests/UnimodMapper_test.py
+++ b/tests/UnimodMapper_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 
 import pyqms

--- a/tests/adaptor_calc_amount_test.py
+++ b/tests/adaptor_calc_amount_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 
 import pyqms

--- a/tests/adaptor_parse_evidence_and_format_fixed_labels_test.py
+++ b/tests/adaptor_parse_evidence_and_format_fixed_labels_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 '''
  Example of data passed::

--- a/tests/adaptor_parse_evidence_file_test.py
+++ b/tests/adaptor_parse_evidence_file_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 '''
  Example of data passed::

--- a/tests/adaptor_read_xlsx_test.py
+++ b/tests/adaptor_read_xlsx_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 '''
 

--- a/tests/build_label_percentile_tuples_test.py
+++ b/tests/build_label_percentile_tuples_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 
 

--- a/tests/carbamido_14N_15N_test.py
+++ b/tests/carbamido_14N_15N_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 '''
 Test if the fixed_labeled is counted into the metabolic_labels

--- a/tests/create_combinations_test.py
+++ b/tests/create_combinations_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 
 

--- a/tests/extend_kb_with_fixed_labels_test.py
+++ b/tests/extend_kb_with_fixed_labels_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 '''
 

--- a/tests/extend_molecules_with_fixed_labels_test.py
+++ b/tests/extend_molecules_with_fixed_labels_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 
 

--- a/tests/group_silac_pairs.py
+++ b/tests/group_silac_pairs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 
 import pyqms

--- a/tests/increase_element_envelope_test.py
+++ b/tests/increase_element_envelope_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 
 

--- a/tests/knowledge_base_tests.py
+++ b/tests/knowledge_base_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 '''
 

--- a/tests/recalc_isotopic_distribution_test.py
+++ b/tests/recalc_isotopic_distribution_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 '''
 

--- a/tests/score_matches_tests.py
+++ b/tests/score_matches_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 '''
 '''

--- a/tests/slice_list_test.py
+++ b/tests/slice_list_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 '''
 

--- a/tests/smooth_list_test.py
+++ b/tests/smooth_list_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 
 import pyqms

--- a/tests/transform_mz_to_set_test.py
+++ b/tests/transform_mz_to_set_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 '''
 

--- a/tests/transform_spectrum_test.py
+++ b/tests/transform_spectrum_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python
 # encoding: utf-8
 '''
 


### PR DESCRIPTION
- Changed all shebangs from .../env python3.4 to .../env python
- setup.py no uses setuptools instead of distutils
- require at least python3.5 to fix compilation of C extensions under windows (https://blog.ionelmc.ro/2014/12/21/compiling-python-extensions-on-windows/)