### PR TITLE
Remove unused version in pyQms/__init__.pyQms

### DIFF
--- a/pyqms/__init__.py
+++ b/pyqms/__init__.py
@@ -21,11 +21,9 @@
 """
 from __future__ import absolute_import
 import sys
-version_info  = (0, 5, 0, 'beta')
-version = '0.5.0-beta'
 
 if not hasattr(sys, "version_info") or sys.version_info < (3, 5):
-    raise RuntimeError("pyQms requires Python 3.3 or later.")
+    raise RuntimeError("pyQms requires Python 3.5 or later.")
 
 from . import knowledge_base
 from .isotopologue_library import IsotopologueLibrary


### PR DESCRIPTION
- remove unused variable version_info hardcoded to (0, 5, 0, 'beta')
- remove unused variable version hardcoded to 0.5.0-beta
- update RuntimeError warning to print correct required version