### PR TITLE
Allow setting of custom colors via params

### DIFF
--- a/pyqms/results.py
+++ b/pyqms/results.py
@@ -722,7 +722,7 @@ class Results(dict):
         color = [0, 0, 0]  # copy becauuuuse  ?
         colorGradient = [
             (score_threshold, rgb_tuple)
-            for (score_threshold, rgb_tuple) in sorted(pyqms.params["COLORS"].items())
+            for (score_threshold, rgb_tuple) in sorted(self.params["COLORS"].items())
         ]
         if score is not None:
             idx = bisect.bisect(colorGradient, (score,))


### PR DESCRIPTION
In the results class the colors for the mScore were always taken from the params.py file. If colors were changed in the params and passed to the results class, they were not used.