### PR TITLE
Store trivial_name for each row of evidence file

### DIFF
--- a/pyqms/adaptors.py
+++ b/pyqms/adaptors.py
@@ -371,7 +371,6 @@ def parse_evidence(
 
                 if molecule not in tmp_evidences.keys():
                     tmp_evidences[molecule] = {"evidences": [], "trivial_names": set()}
-                tmp_evidences[molecule]["evidences"].append(dict_2_append)
                 for trivial_name_key in [
                     "proteinacc_start_stop_pre_post_;",  # old ursgal style
                     "trivial_name",  # self defined name
@@ -382,6 +381,11 @@ def parse_evidence(
                     if additional_name != "":
                         # use set to remove double values
                         tmp_evidences[molecule]["trivial_names"].add(additional_name)
+                        if 'trivial_name' not in dict_2_append.keys():
+                            dict_2_append['trivial_name'] = additional_name
+                        else:
+                            dict_2_append['trivial_name'] += ';{0}'.format(additional_name)                
+                tmp_evidences[molecule]["evidences"].append(dict_2_append)
 
     mod_pattern = re.compile(r""":(?P<pos>[0-9]*$)""")
 

--- a/pyqms/results.py
+++ b/pyqms/results.py
@@ -722,7 +722,7 @@ class Results(dict):
         color = [0, 0, 0]  # copy becauuuuse  ?
         colorGradient = [
             (score_threshold, rgb_tuple)
-            for (score_threshold, rgb_tuple) in sorted(pyqms.params["COLORS"].items())
+            for (score_threshold, rgb_tuple) in sorted(self.params["COLORS"].items())
         ]
         if score is not None:
             idx = bisect.bisect(colorGradient, (score,))

--- a/tests/adaptor_parse_evidence_file_test.py
+++ b/tests/adaptor_parse_evidence_file_test.py
@@ -183,6 +183,15 @@ def adaptor_check(test_dict):
             if len(evidence_lookup[formula][molecule]['trivial_names']) !=0:
                 for ev_dict in evidence_lookup[formula][molecule]['evidences']:
                     assert 'trivial_name' in ev_dict.keys()
+                    trivial_name = ev_dict['trivial_name']
+                    if ';' in trivial_name:
+                        trivial_name_list = trivial_name.split(';')
+                    else:
+                        trivial_name_list = [ trivial_name ]
+                    for tmp_trivial_name in trivial_name_list:
+                        assert tmp_trivial_name in evidence_lookup[formula][molecule]['trivial_names']
+                    assert sorted(evidence_lookup[formula][molecule]['trivial_names']) == sorted(trivial_name_list)
+                    # for trivial_name in ev_dict['trivial_name']
 
 if __name__ == "__main__":
     for test_dict in TESTS:

--- a/tests/adaptor_parse_evidence_file_test.py
+++ b/tests/adaptor_parse_evidence_file_test.py
@@ -177,7 +177,12 @@ def adaptor_check(test_dict):
     # print(molecule_list)
     assert len(molecule_list) == len(test_dict["output"]["molecules"])
     assert sorted(molecule_list) == sorted(test_dict["output"]["molecules"])
-
+    print(evidence_lookup)
+    for formula in evidence_lookup.keys():
+        for molecule in evidence_lookup[formula].keys():
+            if len(evidence_lookup[formula][molecule]['trivial_names']) !=0:
+                for ev_dict in evidence_lookup[formula][molecule]['evidences']:
+                    assert 'trivial_name' in ev_dict.keys()
 
 if __name__ == "__main__":
     for test_dict in TESTS:

--- a/tests/adaptor_parse_evidence_file_test.py
+++ b/tests/adaptor_parse_evidence_file_test.py
@@ -174,10 +174,8 @@ def adaptor_check(test_dict):
     formatted_fixed_labels, evidence_lookup, molecule_list = parse_evidence(
         **test_dict["input"]
     )
-    # print(molecule_list)
     assert len(molecule_list) == len(test_dict["output"]["molecules"])
     assert sorted(molecule_list) == sorted(test_dict["output"]["molecules"])
-    print(evidence_lookup)
     for formula in evidence_lookup.keys():
         for molecule in evidence_lookup[formula].keys():
             if len(evidence_lookup[formula][molecule]['trivial_names']) !=0:
@@ -191,7 +189,6 @@ def adaptor_check(test_dict):
                     for tmp_trivial_name in trivial_name_list:
                         assert tmp_trivial_name in evidence_lookup[formula][molecule]['trivial_names']
                     assert sorted(evidence_lookup[formula][molecule]['trivial_names']) == sorted(trivial_name_list)
-                    # for trivial_name in ev_dict['trivial_name']
 
 if __name__ == "__main__":
     for test_dict in TESTS:


### PR DESCRIPTION
This adds the storage of each trivial_name for each row in the evidence file. Code works as before but now one can dissect evidence RTs for different molecules with different elution times with the same formula, e.g. isomers of nucleosides.